### PR TITLE
Fix URL on the go get instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Getting started
 
 
     ```bash
-    $ go get github.com/erroneouboat/slack-term
+    $ go get github.com/erroneousboat/slack-term
     ```
 
 2. Get a slack token, click [here](https://api.slack.com/docs/oauth-test-tokens) 


### PR DESCRIPTION
Hey!

I was trying to fetch the code by using your `go get` instructions and I noticed this small typo.

Thanks for the project!
