### PR TITLE
Added config to filter non member channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Getting started
         // OPTIONAL: set the width of the sidebar (between 1 and 11), default is 1
         "sidebar_width": 3,
 
+        // OPTIONAL: if true it will only show channels you are a member of, default is false
+        "member_only": true,
+
         // OPTIONAL: define custom key mappings, defaults are:
         "key_map": {
             "command": {

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	SlackToken   string                `json:"slack_token"`
 	Theme        string                `json:"theme"`
 	SidebarWidth int                   `json:"sidebar_width"`
+	MemberOnly   bool                  `json:"member_only"`
 	MainWidth    int                   `json:"-"`
 	KeyMap       map[string]keyMapping `json:"key_map"`
 }
@@ -25,6 +26,7 @@ func NewConfig(filepath string) (*Config, error) {
 		Theme:        "dark",
 		SidebarWidth: 1,
 		MainWidth:    11,
+		MemberOnly:   false,
 		KeyMap: map[string]keyMapping{
 			"command": {
 				"i":          "mode-insert",

--- a/context/context.go
+++ b/context/context.go
@@ -33,7 +33,7 @@ func CreateAppContext(flgConfig string) *AppContext {
 	}
 
 	// Create Service
-	svc := service.NewSlackService(config.SlackToken)
+	svc := service.NewSlackService(config.SlackToken, config.MemberOnly)
 
 	// Create ChatView
 	view := views.CreateChatView(svc)


### PR DESCRIPTION
This adds a `member_only` flag to your config to allow you to filter channels that you are a member of only.