### PR TITLE
Add snapcraft support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: slack-term
+version: git
+summary: Slack client for your terminal
+description: |
+  A Slack client for your terminal.
+  * Get a slack token from https://api.slack.com/docs/oauth-test-tokens
+  * Create $HOME/snap/slack-term/current/slack-term.json
+  * Contents detailed at https://github.com/erroneousboat/slack-term
+  * slack-term --config $HOME/snap/slack-term/current/slack-term.json
+
+grade: stable
+confinement: strict
+
+apps:
+  slack-term:
+    command: slack-term
+    plugs:
+      - network
+      - home
+
+parts:
+  go:
+    source-tag: go1.7.5
+  slack-term:
+    after: [go]
+    source: https://github.com/erroneousboat/slack-term.git
+    plugin: go
+    go-importpath: github.com/erroneousboat/slack-term

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,6 @@ parts:
     source-tag: go1.7.5
   slack-term:
     after: [go]
-    source: https://github.com/erroneousboat/slack-term.git
+    source: .
     plugin: go
     go-importpath: github.com/erroneousboat/slack-term


### PR DESCRIPTION
This pull request adds support to build slack-term as a snap.

slack-term is already [available](https://snapcraft.io/slack-term/) in the snap store via the yaml in the [snapcrafter](https://github.com/snapcrafters/slack-term).

This PR is to upstream the snapcraft.yaml which creates the snap which is in the store. If the PR is accepted, we can transfer ownership of the slack-term snap to you, the upstream developer. Once done you could use the free build.snapcraft.io service to automatically build new releases of slack-term and push directly to the store. 

If accepted, I'm happy to walk you through the next steps. 