### PR TITLE
use link_names in postMessage to enable auto linking of names and channels

### DIFF
--- a/service/slack.go
+++ b/service/slack.go
@@ -338,6 +338,7 @@ func (s *SlackService) SendMessage(channelID int, message string) {
 	postParams := slack.PostMessageParameters{
 		AsUser:   true,
 		Username: s.CurrentUsername,
+		LinkNames: 1,
 	}
 
 	// https://godoc.org/github.com/nlopes/slack#Client.PostMessage


### PR DESCRIPTION
this should mean that typing `@bob` will ping bob, and that channels will be clickable in the web ui. 

fixes #134 