### PR TITLE
Provided message deltas (date changes and unread markers)

### DIFF
--- a/components/channels.go
+++ b/components/channels.go
@@ -3,6 +3,7 @@ package components
 import (
 	"fmt"
 	"html"
+	"time"
 
 	"github.com/erroneousboat/termui"
 	"github.com/renstrom/fuzzysearch/fuzzy"
@@ -32,6 +33,7 @@ type ChannelItem struct {
 	UserID       string
 	Presence     string
 	Notification bool
+	LastReadTime time.Time
 
 	StylePrefix string
 	StyleIcon   string
@@ -89,6 +91,11 @@ func (c ChannelItem) GetChannelName() string {
 		channelName = c.Name
 	}
 	return channelName
+}
+
+// Sets the last read time for a channel
+func (c *ChannelItem) SetLastReadTime(readTime time.Time) {
+	c.LastReadTime = readTime
 }
 
 // Channels is the definition of a Channels component

--- a/components/chat.go
+++ b/components/chat.go
@@ -47,6 +47,7 @@ func (m Message) ToString() string {
 type Chat struct {
 	List   *termui.List
 	Offset int
+    LastMessageTime time.Time
 }
 
 // CreateChat is the constructor for the Chat struct
@@ -60,6 +61,10 @@ func CreateChatComponent(inputHeight int) *Chat {
 	chat.List.Overflow = "wrap"
 
 	return chat
+}
+
+func OnSameDate(a time.Time, b time.Time) bool {
+    return a.Day() == b.Day() && a.Month() == b.Month() && a.Year() == b.Year()
 }
 
 // Buffer implements interface termui.Bufferer
@@ -198,21 +203,58 @@ func (c *Chat) GetMaxItems() int {
 	return c.List.InnerBounds().Max.Y - c.List.InnerBounds().Min.Y
 }
 
+func (c *Chat) ShowTimeDelta(message Message) {
+    if !message.Time.IsZero() {
+        inDelta := OnSameDate(c.LastMessageTime, message.Time)
+        if !inDelta {
+            c.AddTimeMarker(time.Time.Format(message.Time, "Mon, Jan 2 2006"))
+        }
+        c.LastMessageTime = message.Time
+    }
+
+}
+
 // SetMessages will put the provided messages into the Items field of the
 // Chat view
-func (c *Chat) SetMessages(messages []string) {
+func (c *Chat) SetMessages(messages []Message) {
 	// Reset offset first, when scrolling in view and changing channels we
 	// want the offset to be 0 when loading new messages
 	c.Offset = 0
+    if c.LastMessageTime.IsZero() {
+        c.LastMessageTime = time.Now()
+    }
 
 	for _, msg := range messages {
-		c.List.Items = append(c.List.Items, html.UnescapeString(msg))
+        c.ShowTimeDelta(msg)
+        strMsg := msg.ToString()
+		c.List.Items = append(c.List.Items, html.UnescapeString(strMsg))
 	}
 }
 
+func (c *Chat) AddTimeMarker(marker string) {
+    screenWidth := c.List.Width
+    markerWidth := len(marker)
+    split := ((screenWidth - markerWidth) / 2) - 4
+    if split < 0 {
+        // sometimes we don't know the width yet, so arbitrarily, 10.
+        split = 10
+    }
+    prefix := strings.Repeat("─", split+1)
+    suffix := strings.Repeat("─", split+1)
+    // because this doesn't always divide evenly, add a little extra nudge
+    if int(split) + int(split) + markerWidth + 8 < screenWidth {
+        prefix = "─" + prefix
+    }
+
+    line := fmt.Sprintf(" %s %s %s ", prefix, marker, suffix)
+    c.List.Items = append(c.List.Items, line)
+}
+
 // AddMessage adds a single message to List.Items
-func (c *Chat) AddMessage(message string) {
-	c.List.Items = append(c.List.Items, html.UnescapeString(message))
+func (c *Chat) AddMessage(message Message) {
+    c.ShowTimeDelta(message)
+    strMsg := message.ToString()
+	c.List.Items = append(c.List.Items, html.UnescapeString(strMsg))
 }
 
 // ClearMessages clear the List.Items

--- a/components/chat.go
+++ b/components/chat.go
@@ -235,10 +235,8 @@ func (c *Chat) SetMessages(messages []Message) {
 		unreadDeltaAdded = true
 	}
 
-	//print(fmt.Sprintf("last read: %v", c.LastReadTime))
 	for _, msg := range messages {
 		c.ShowTimeDelta(msg)
-		//print(fmt.Sprintf("message time: %v", msg.Time))
 		if unreadDeltaAdded == false {
 			if msg.Time.UTC().After(c.LastReadTime.UTC()) {
 				c.AddUnreadDelta()
@@ -254,7 +252,7 @@ func (c *Chat) AddUnreadDelta() {
 	unreadLabel := "new messages"
 	screenWidth := c.List.Width
 	markerWidth := len(unreadLabel)
-	split := screenWidth - markerWidth - 4
+	split := screenWidth - markerWidth - 5
 	if split < 0 {
 		// sometimes we don't know the width yet, so arbitrarily, 10.
 		split = 10

--- a/context/context.go
+++ b/context/context.go
@@ -29,7 +29,6 @@ type AppContext struct {
 	Debug      bool
 	Mode       string
 	Notify     *notificator.Notificator
-	LastReads  map[int]int64
 }
 
 // CreateAppContext creates an application context which can be passed
@@ -107,6 +106,5 @@ func CreateAppContext(flgConfig string, flgToken string, flgDebug bool) (*AppCon
 		Debug:      flgDebug,
 		Mode:       CommandMode,
 		Notify:     notificator.New(notificator.Options{AppName: "slack-term"}),
-		LastReads:  map[int]int64{},
 	}, nil
 }

--- a/context/context.go
+++ b/context/context.go
@@ -29,6 +29,7 @@ type AppContext struct {
 	Debug      bool
 	Mode       string
 	Notify     *notificator.Notificator
+	LastReads  map[int]int64
 }
 
 // CreateAppContext creates an application context which can be passed
@@ -106,5 +107,6 @@ func CreateAppContext(flgConfig string, flgToken string, flgDebug bool) (*AppCon
 		Debug:      flgDebug,
 		Mode:       CommandMode,
 		Notify:     notificator.New(notificator.Options{AppName: "slack-term"}),
+		LastReads:  map[int]int64{},
 	}, nil
 }

--- a/handlers/event.go
+++ b/handlers/event.go
@@ -299,7 +299,13 @@ func actionGetMessages(ctx *context.AppContext) {
 		ctx.View.Chat.GetMaxItems(),
 	)
 
+	//lastRead, emptyLastRead := ctx.LastReads[ctx.View.Channels.SelectedChannel]
+
+	//if !emptyLastRead {
+	//    ctx.View.Chat.SetLastReadTime(lastRead)
+	//}
 	ctx.View.Chat.SetMessages(msgs)
+	//ctx.LastReads[ctx.View.Channels.SelectedChannel] = time.Now()
 
 	termui.Render(ctx.View.Chat)
 }
@@ -375,6 +381,12 @@ func actionChangeChannel(ctx *context.AppContext) {
 		ctx.View.Chat.GetMaxItems(),
 	)
 
+	lastRead, ok := ctx.LastReads[ctx.View.Channels.SelectedChannel]
+
+	if ok {
+		lastReadTime := time.Unix(lastRead, 0)
+		ctx.View.Chat.SetLastReadTime(lastReadTime)
+	}
 	// Set messages for the channel
 	ctx.View.Chat.SetMessages(msgs)
 
@@ -385,6 +397,8 @@ func actionChangeChannel(ctx *context.AppContext) {
 
 	// Clear notification icon if there is any
 	ctx.Service.MarkAsRead(ctx.View.Channels.SelectedChannel)
+	ctx.LastReads[ctx.View.Channels.SelectedChannel] = int64(time.Now().Unix())
+
 	ctx.View.Channels.SetChannels(ctx.Service.ChannelsToString())
 
 	termui.Render(ctx.View.Channels)

--- a/handlers/event.go
+++ b/handlers/event.go
@@ -121,7 +121,7 @@ func messageHandler(ctx *context.AppContext) {
 						// when attachments are added to message
 						for i := len(msg) - 1; i >= 0; i-- {
 							ctx.View.Chat.AddMessage(
-								msg[i].ToString(),
+								msg[i],
 							)
 						}
 
@@ -299,12 +299,7 @@ func actionGetMessages(ctx *context.AppContext) {
 		ctx.View.Chat.GetMaxItems(),
 	)
 
-	var strMsgs []string
-	for _, msg := range msgs {
-		strMsgs = append(strMsgs, msg.ToString())
-	}
-
-	ctx.View.Chat.SetMessages(strMsgs)
+	ctx.View.Chat.SetMessages(msgs)
 
 	termui.Render(ctx.View.Chat)
 }
@@ -380,13 +375,8 @@ func actionChangeChannel(ctx *context.AppContext) {
 		ctx.View.Chat.GetMaxItems(),
 	)
 
-	var strMsgs []string
-	for _, msg := range msgs {
-		strMsgs = append(strMsgs, msg.ToString())
-	}
-
 	// Set messages for the channel
-	ctx.View.Chat.SetMessages(strMsgs)
+	ctx.View.Chat.SetMessages(msgs)
 
 	// Set channel name for the Chat pane
 	ctx.View.Chat.SetBorderLabel(

--- a/service/slack.go
+++ b/service/slack.go
@@ -128,14 +128,15 @@ func (s *SlackService) GetChannels() []string {
 			s.SlackChannels = append(s.SlackChannels, chn)
 			chans = append(
 				chans, components.ChannelItem{
-					ID:          chn.ID,
-					Name:        chn.Name,
-					Topic:       chn.Topic.Value,
-					Type:        components.ChannelTypeChannel,
-					UserID:      "",
-					StylePrefix: s.Config.Theme.Channel.Prefix,
-					StyleIcon:   s.Config.Theme.Channel.Icon,
-					StyleText:   s.Config.Theme.Channel.Text,
+					ID:           chn.ID,
+					Name:         chn.Name,
+					Topic:        chn.Topic.Value,
+					Type:         components.ChannelTypeChannel,
+					UserID:       "",
+					StylePrefix:  s.Config.Theme.Channel.Prefix,
+					StyleIcon:    s.Config.Theme.Channel.Icon,
+					StyleText:    s.Config.Theme.Channel.Text,
+					LastReadTime: time.Now().UTC(),
 				},
 			)
 		}
@@ -146,14 +147,15 @@ func (s *SlackService) GetChannels() []string {
 		s.SlackChannels = append(s.SlackChannels, grp)
 		chans = append(
 			chans, components.ChannelItem{
-				ID:          grp.ID,
-				Name:        grp.Name,
-				Topic:       grp.Topic.Value,
-				Type:        components.ChannelTypeGroup,
-				UserID:      "",
-				StylePrefix: s.Config.Theme.Channel.Prefix,
-				StyleIcon:   s.Config.Theme.Channel.Icon,
-				StyleText:   s.Config.Theme.Channel.Text,
+				ID:           grp.ID,
+				Name:         grp.Name,
+				Topic:        grp.Topic.Value,
+				Type:         components.ChannelTypeGroup,
+				UserID:       "",
+				StylePrefix:  s.Config.Theme.Channel.Prefix,
+				StyleIcon:    s.Config.Theme.Channel.Icon,
+				StyleText:    s.Config.Theme.Channel.Text,
+				LastReadTime: time.Now().UTC(),
 			},
 		)
 	}
@@ -171,15 +173,16 @@ func (s *SlackService) GetChannels() []string {
 			chans = append(
 				chans,
 				components.ChannelItem{
-					ID:          im.ID,
-					Name:        name,
-					Topic:       "",
-					Type:        components.ChannelTypeIM,
-					UserID:      im.User,
-					Presence:    "",
-					StylePrefix: s.Config.Theme.Channel.Prefix,
-					StyleIcon:   s.Config.Theme.Channel.Icon,
-					StyleText:   s.Config.Theme.Channel.Text,
+					ID:           im.ID,
+					Name:         name,
+					Topic:        "",
+					Type:         components.ChannelTypeIM,
+					UserID:       im.User,
+					Presence:     "",
+					StylePrefix:  s.Config.Theme.Channel.Prefix,
+					StyleIcon:    s.Config.Theme.Channel.Icon,
+					StyleText:    s.Config.Theme.Channel.Text,
+					LastReadTime: time.Now().UTC(),
 				},
 			)
 			s.SlackChannels = append(s.SlackChannels, im)
@@ -282,6 +285,7 @@ func (s *SlackService) SetChannelReadMark(channel interface{}) {
 // MarkAsRead will set the channel as read
 func (s *SlackService) MarkAsRead(channelID int) {
 	channel := s.Channels[channelID]
+	s.Channels[channelID].SetLastReadTime(time.Now().UTC())
 
 	if channel.Notification {
 		s.Channels[channelID].Notification = false

--- a/views/view.go
+++ b/views/view.go
@@ -37,12 +37,7 @@ func CreateView(config *config.Config, svc *service.SlackService) *View {
 		chat.GetMaxItems(),
 	)
 
-	var strMsgs []string
-	for _, msg := range msgs {
-		strMsgs = append(strMsgs, msg.ToString())
-	}
-
-	chat.SetMessages(strMsgs)
+    chat.SetMessages(msgs)
 	chat.SetBorderLabel(svc.Channels[channels.SelectedChannel].GetChannelName())
 
 	// Debug: create the component


### PR DESCRIPTION
So as I'm jumping around between my unread channels, sometimes I'm not sure where the conversation started that I missed. So now a nice big " ──────────── new messages " runs across the screen signifying the last known time I looked at the channel.

**NOTE** This doesn't change the slack-term core functionality and actually query slack for the unread notifications. It's all in the local session's memory.

Also there's now a " ------- {date} ------- " separator in chats to separate the daily messages. The timestamps visible on the left of the chat only showed "time" so it was sometimes difficult to determine at a glance when a message came in. This helps.