### PR TITLE
Show message in notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Setup
     // value as: "mention", default is turned off: ""
     "notify": "",
 
+    // OPTIONAL: display sender and message content in notifications, set
+    // the value as: false, default is to hide message content: true
+    "notify_private": true,
+
     // OPTIONAL: define custom key mappings, defaults are:
     "key_map": {
         "command": {

--- a/config/config.go
+++ b/config/config.go
@@ -16,12 +16,13 @@ const (
 
 // Config is the definition of a Config struct
 type Config struct {
-	SlackToken   string                `json:"slack_token"`
-	Notify       string                `json:"notify"`
-	SidebarWidth int                   `json:"sidebar_width"`
-	MainWidth    int                   `json:"-"`
-	KeyMap       map[string]keyMapping `json:"key_map"`
-	Theme        Theme                 `json:"theme"`
+	SlackToken    string                `json:"slack_token"`
+	Notify        string                `json:"notify"`
+	NotifyPrivate bool                  `json:"notify_private"`
+	SidebarWidth  int                   `json:"sidebar_width"`
+	MainWidth     int                   `json:"-"`
+	KeyMap        map[string]keyMapping `json:"key_map"`
+	Theme         Theme                 `json:"theme"`
 }
 
 type keyMapping map[string]string
@@ -66,9 +67,10 @@ func NewConfig(filepath string) (*Config, error) {
 
 func getDefaultConfig() Config {
 	return Config{
-		SidebarWidth: 1,
-		MainWidth:    11,
-		Notify:       "",
+		SidebarWidth:  1,
+		MainWidth:     11,
+		Notify:        "",
+		NotifyPrivate: true,
 		KeyMap: map[string]keyMapping{
 			"command": {
 				"i":          "mode-insert",

--- a/handlers/event.go
+++ b/handlers/event.go
@@ -501,10 +501,22 @@ func createNotifyMessage(ctx *context.AppContext, ev *slack.MessageEvent) {
 		notifyTimer = time.NewTimer(time.Second * 2)
 		<-notifyTimer.C
 
+		var title string
+		var msg string
+
+		if ctx.Config.NotifyPrivate {
+			title = "slack-term"
+			msg = ctx.Service.CreateNotifyMessage(ev.Channel)
+		} else {
+			title = ctx.Service.GetChannelName(ev.Channel)
+			msg = ev.Text
+		}
+
 		// Only actually notify when time expires
 		ctx.Notify.Push(
-			"slack-term",
-			ctx.Service.CreateNotifyMessage(ev.Channel), "",
+			title,
+			msg,
+			"",
 			notificator.UR_NORMAL,
 		)
 	}()


### PR DESCRIPTION
Thanks for this awesome slack cli client. It's fully replaced the RAM intensive default for me. The only thing I missed was seeing the message content within notifications. So I added them in!

---

Adds an option to show the message content as part of the notification toast instead of the generic `Message received [on channel | in group | from]: <identifier>`.