### PR TITLE
Respect the XDG Base Directory specification for configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ ENV USER root
 COPY --from=builder /usr/bin/slack-term /usr/bin/slack-term
 COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs
 
-ENTRYPOINT stty cols 25 && slack-term -config .slack-term
+ENTRYPOINT stty cols 25 && slack-term -config ~/.config/slack-term/config

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ $ go install .
 Setup
 -----
 
-1. Get a slack token, click [here](https://api.slack.com/docs/oauth-test-tokens) 
+1. Get a slack token, click [here](https://api.slack.com/docs/oauth-test-tokens)
 
-2. Create a `.slack-term` file, and place it in your home directory. Below is
-   an example of such a file. You are only required to specify a
-   `slack_token`. For more configuration options of the `.slack-term` file,
-   see the [wiki](https://github.com/erroneousboat/slack-term/wiki).
+2. Create a file named `config` in the `$XDG_CONFIG_HOME/slack-term` directory
+   (the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+   specifies `$HOME/.config/` if you do not have `$XDG_CONFIG_HOME` explicitly
+   set). Below is an example of such a file. You are only required to specify a
+   `slack_token`. For more configuration options of the `config` file, see
+   the [wiki](https://github.com/erroneousboat/slack-term/wiki).
 
 ```javascript
 {
@@ -49,7 +51,7 @@ Usage
 -----
 
 When everything is setup correctly you can run `slack-term` with the following
-command: 
+command:
 
 ```bash
 $ slack-term
@@ -59,7 +61,7 @@ Default Key Mapping
 -------------------
 
 Below are the default key-mappings for `slack-term`, you can change them
-in your `.slack-term` file.
+in your `config` file.
 
 | mode    | key       | action                     |
 |---------|-----------|----------------------------|

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/0xAX/notificator v0.0.0-20171022182052-88d57ee9043b
+	github.com/OpenPeeDeeP/xdg v0.2.0
 	github.com/erroneousboat/termui v0.0.0-20170923115141-80f245cdfa04
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/maruel/panicparse v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/0xAX/notificator v0.0.0-20171022182052-88d57ee9043b h1:Sn+u6zpXFyfm2X7ruh+z6SJiUVyFg8YElh6HIOhrRCA=
 github.com/0xAX/notificator v0.0.0-20171022182052-88d57ee9043b/go.mod h1:NtXa9WwQsukMHZpjNakTTz0LArxvGYdPA9CjIcUSZ6s=
+github.com/OpenPeeDeeP/xdg v0.2.0 h1:xr89rnllbkRkM7SV9Y++FJ8TGkbdkhhBQm5kOkGT7AE=
+github.com/OpenPeeDeeP/xdg v0.2.0/go.mod h1:tMoSueLQlMf0TCldjrJLNIjAc5qAOIcHt5REi88/Ygo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/erroneousboat/termui v0.0.0-20170923115141-80f245cdfa04 h1:DaFwoQC0Neeb2y2CVFxDPrS1BeyWAkKc4VVBDTZ0N98=
@@ -24,5 +26,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/renstrom/fuzzysearch v1.0.1 h1:hnh2Fhqqa5I41Xgmm7UMAYgEIRn/iZwWItfwUHr1IWE=
 github.com/renstrom/fuzzysearch v1.0.1/go.mod h1:SAEjPB4voP88qmWJXI7mA5m15uNlEnuHLx4Eu2mPGpQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"path"
 
+	"github.com/OpenPeeDeeP/xdg"
 	"github.com/erroneousboat/termui"
 	termbox "github.com/nsf/termbox-go"
 
@@ -16,7 +17,7 @@ import (
 )
 
 const (
-	VERSION = "v0.4.1"
+	VERSION = "v0.4.2"
 	USAGE   = `NAME:
     slack-term - slack client for your terminal
 
@@ -51,11 +52,19 @@ func init() {
 		log.Fatal(err)
 	}
 
+	// Find the default config file
+	xdg := xdg.New("slack-term", "")
+	configFile := xdg.QueryConfig("config")
+	if configFile == "" {
+		// Fall back to $HOME/.slack_term for legacy compatibility
+		configFile = path.Join(usr.HomeDir, ".slack-term")
+	}
+
 	// Parse flags
 	flag.StringVar(
 		&flgConfig,
 		"config",
-		path.Join(usr.HomeDir, ".slack-term"),
+		configFile,
 		"location of config file",
 	)
 


### PR DESCRIPTION
Rather than assuming a configuration file at `~/.slack-term`, respect
the user's choice per the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
to find the configuration.

Uses a cross-platform [XDG library](https://github.com/OpenPeeDeeP/xdg) ([godoc](https://godoc.org/github.com/OpenPeeDeeP/xdg)) to abstract the details of the
specification and encompass any future changes.

After merging, the [wiki home page](https://github.com/erroneousboat/slack-term/wiki)
should be updated to reflect the new configuration location.

This closes #170 and closes #203.