### PR TITLE
Add option to only show unread messages

### DIFF
--- a/components/channels.go
+++ b/components/channels.go
@@ -27,23 +27,23 @@ const (
 )
 
 type ChannelItem struct {
-	ID           string
-	Name         string
-	Topic        string
-	Type         string
-	UserID       string
-	Presence     string
-	Notification bool
-
-	StylePrefix string
-	StyleIcon   string
-	StyleText   string
+	ID             string
+	Name           string
+	Topic          string
+	Type           string
+	UserID         string
+	Presence       string
+	Notification   bool
+	StylePrefix    string
+	StyleIcon      string
+	StyleText      string
+	IsSearchResult bool
 }
 
 // ToString will set the label of the channel, how it will be
 // displayed on screen. Based on the type, different icons are
 // shown, as well as an optional notification icon.
-func (c ChannelItem) ToString() string {
+func (c *ChannelItem) ToString() string {
 	var prefix string
 	if c.Notification {
 		prefix = IconNotification
@@ -82,7 +82,7 @@ func (c ChannelItem) ToString() string {
 
 // GetChannelName will return a formatted representation of the
 // name of the channel
-func (c ChannelItem) GetChannelName() string {
+func (c *ChannelItem) GetChannelName() string {
 	var channelName string
 	if c.Topic != "" {
 		channelName = fmt.Sprintf("%s - %s",
@@ -97,41 +97,76 @@ func (c ChannelItem) GetChannelName() string {
 
 // Channels is the definition of a Channels component
 type Channels struct {
-	ChannelItems    []ChannelItem
-	List            *termui.List
-	SelectedChannel int // index of which channel is selected from the List
-	Offset          int // from what offset are channels rendered
-	CursorPosition  int // the y position of the 'cursor'
-
-	SearchMatches  []int // index of the search matches
-	SearchPosition int   // current position of a search match
+	ChannelItems    map[string]*ChannelItem // mapping of channel IDs to ChannelItems
+	CursorPosition  int                     // the y position of the cursor in this component
+	List            *termui.List            // ui of visible channels
+	Offset          int                     // offset in channel list from which items are render
+	SearchPosition  int                     // current position in search results
+	SelectedChannel string                  // index of which channel is selected from the List
+	UnreadOnly      bool                    // only show unread messages when on
+	itemsRendered   int                     // the number of items currently rendered on screen
+	channelIDs      []string                // sorted list of channel IDs; the nth sortedChannels has the nth alphabetically significant ChannelItem.Name
 }
 
 // CreateChannels is the constructor for the Channels component
-func CreateChannelsComponent(height int) *Channels {
+func CreateChannelsComponent(height int, unreadOnly bool) *Channels {
 	channels := &Channels{
 		List: termui.NewList(),
 	}
 
-	channels.List.BorderLabel = "Channels"
+	channels.List.BorderLabel = "Conversations"
 	channels.List.Height = height
 
-	channels.SelectedChannel = 0
+	channels.SelectedChannel = ""
+	channels.CursorPosition = channels.minY()
 	channels.Offset = 0
-	channels.CursorPosition = channels.List.InnerBounds().Min.Y
+	channels.UnreadOnly = unreadOnly
+	channels.ChannelItems = make(map[string]*ChannelItem)
 
 	return channels
+}
+
+// ListChannels lists all visible channels
+// if the application has UnreadOnly disabled, list all channels
+// if the application has UnreadOnly enabled
+//  - always includes the currently selected channel (if one is selected)
+//  - always show channels that match the current search
+//  - never show channels that are read and match neither of the above conditions
+func (c *Channels) ListChannels() (items []*ChannelItem) {
+
+	if !c.UnreadOnly {
+		for _, id := range c.channelIDs {
+			items = append(items, c.ChannelItems[id])
+		}
+
+		return
+	}
+
+	// filter by messages that are either unread or search results ( always show selected channel)
+	for _, id := range c.channelIDs {
+
+		chn := c.ChannelItems[id]
+		if c.shouldBeVisible(chn) {
+			items = append(items, chn)
+		}
+	}
+
+	return
 }
 
 // Buffer implements interface termui.Bufferer
 func (c *Channels) Buffer() termui.Buffer {
 	buf := c.List.Buffer()
 
-	for i, item := range c.ChannelItems[c.Offset:] {
+	c.itemsRendered = 0
 
-		y := c.List.InnerBounds().Min.Y + i
+	for i, item := range c.ListChannels()[c.Offset:] {
 
-		if y > c.List.InnerBounds().Max.Y-1 {
+		y := c.minY() + i
+
+		c.itemsRendered++
+
+		if y > c.maxY()-1 {
 			break
 		}
 
@@ -201,112 +236,178 @@ func (c *Channels) SetY(y int) {
 	c.List.SetY(y)
 }
 
-func (c *Channels) SetChannels(channels []ChannelItem) {
-	c.ChannelItems = channels
-}
+// SetChannels sets the channel list for this component.
+// `channels` is assumed to be sorted
+func (c *Channels) SetChannels(channels []*ChannelItem) {
 
-func (c *Channels) MarkAsRead(channelID int) {
-	c.ChannelItems[channelID].Notification = false
-}
+	c.channelIDs = make([]string, len(channels))
 
-func (c *Channels) MarkAsUnread(channelID string) {
-	index := c.FindChannel(channelID)
-	c.ChannelItems[index].Notification = true
-}
-
-func (c *Channels) SetPresence(channelID string, presence string) {
-	index := c.FindChannel(channelID)
-	c.ChannelItems[index].Presence = presence
-}
-
-func (c *Channels) FindChannel(channelID string) int {
-	var index int
-	for i, channel := range c.ChannelItems {
-		if channel.ID == channelID {
-			index = i
-			break
-		}
+	for i, chn := range channels {
+		c.channelIDs[i] = chn.ID
+		c.ChannelItems[chn.ID] = chn
 	}
-	return index
+
+	// select the first channel by default when UnreadOnly is disabled
+	if len(channels) > 0 && !c.UnreadOnly {
+		c.SetSelectedChannel(c.ChannelItems[c.channelIDs[0]].ID)
+	}
 }
 
-// SetSelectedChannel sets the SelectedChannel given the index
-func (c *Channels) SetSelectedChannel(index int) {
-	c.SelectedChannel = index
+// MarkAsRead marks a channel as read
+func (c *Channels) MarkAsRead(channelID string) {
+
+	if chn, ok := c.ChannelItems[channelID]; ok {
+		chn.Notification = false
+	}
+}
+
+// MarkAsUnread marks a channel as unread
+func (c *Channels) MarkAsUnread(channelID string) {
+
+	if chn, ok := c.ChannelItems[channelID]; ok {
+		chn.Notification = true
+	}
+
+	// the cursor may need to be repositioned now that more channels
+	// may be visible
+	c.ScrollToChannel(c.SelectedChannel)
+}
+
+// SetPresence sets the presnce on a given channel
+func (c *Channels) SetPresence(channelID string, presence string) {
+
+	if chn, ok := c.ChannelItems[channelID]; ok {
+		chn.Presence = presence
+	}
+}
+
+// SetSelectedChannel sets the SelectedChannel given its ID
+func (c *Channels) SetSelectedChannel(channelID string) {
+
+	if _, ok := c.ChannelItems[channelID]; ok {
+		c.SelectedChannel = channelID
+	}
 }
 
 // Get SelectedChannel returns the ChannelItem that is currently selected
-func (c *Channels) GetSelectedChannel() ChannelItem {
-	return c.ChannelItems[c.SelectedChannel]
+// return
+// - selected: the selected channel item
+// - ok: true if there exists a selected channel item in the channel list
+func (c *Channels) GetSelectedChannel() (selected *ChannelItem, ok bool) {
+
+	if chn, ok := c.ChannelItems[c.SelectedChannel]; ok {
+		return chn, ok
+	}
+
+	return
 }
 
-// MoveCursorUp will decrease the SelectedChannel by 1
-func (c *Channels) MoveCursorUp() {
-	if c.SelectedChannel > 0 {
-		c.SetSelectedChannel(c.SelectedChannel - 1)
-		c.ScrollUp()
+// GetPreviousChannel gets the channel item that preceeds the selected channel item in the visible channel list
+func (c *Channels) GetPreviousChannel() (prev *ChannelItem, ok bool) {
+
+	var selectedChannel *ChannelItem
+
+	// return the current channel when at the top of channel list
+	if c.CursorPosition == c.minY() {
+		if selectedChannel, ok = c.GetSelectedChannel(); ok {
+			prev = selectedChannel
+			return
+		}
 	}
+
+	for _, currID := range c.channelIDs {
+		if currID == c.SelectedChannel && prev.ID != "" {
+			ok = true
+			break
+		}
+
+		chn := c.ChannelItems[currID]
+		if c.shouldBeVisible(chn) {
+			prev = c.ChannelItems[currID]
+		}
+	}
+
+	return
 }
 
-// MoveCursorDown will increase the SelectedChannel by 1
-func (c *Channels) MoveCursorDown() {
-	if c.SelectedChannel < len(c.ChannelItems)-1 {
-		c.SetSelectedChannel(c.SelectedChannel + 1)
-		c.ScrollDown()
+// GetNextChannel gets the channel item that proceeds the selected channel item in the visible channel list
+func (c *Channels) GetNextChannel() (next *ChannelItem, ok bool) {
+
+	var selectedChannel *ChannelItem
+
+	// return the current channel when at the bottom of channel list
+	if c.CursorPosition == c.maxCursorPos() {
+		if selectedChannel, ok = c.GetSelectedChannel(); ok {
+			next = selectedChannel
+			return
+		}
 	}
+
+	for i := len(c.channelIDs) - 1; i >= 0; i-- {
+
+		currID := c.channelIDs[i]
+		if currID == c.SelectedChannel && next.ID != "" {
+			ok = true
+			break
+		}
+
+		chn := c.ChannelItems[currID]
+		if c.shouldBeVisible(chn) {
+			next = c.ChannelItems[currID]
+		}
+	}
+
+	return
 }
 
 // MoveCursorTop will move the cursor to the top of the channels
 func (c *Channels) MoveCursorTop() {
-	c.SetSelectedChannel(0)
-	c.CursorPosition = c.List.InnerBounds().Min.Y
-	c.Offset = 0
+
+	if list := c.ListChannels(); len(list) > 0 {
+		firstChn := list[0]
+		c.SetSelectedChannel(firstChn.ID)
+		c.ScrollToChannel(firstChn.ID)
+	}
 }
 
 // MoveCursorBottom will move the cursor to the bottom of the channels
 func (c *Channels) MoveCursorBottom() {
-	c.SetSelectedChannel(len(c.ChannelItems) - 1)
 
-	offset := len(c.ChannelItems) - (c.List.InnerBounds().Max.Y - 1)
-
-	if offset < 0 {
-		c.Offset = 0
-		c.CursorPosition = c.SelectedChannel + 1
-	} else {
-		c.Offset = offset
-		c.CursorPosition = c.List.InnerBounds().Max.Y - 1
+	if list := c.ListChannels(); len(list) > 0 {
+		index := len(list) - 1
+		lastChn := list[index]
+		c.SetSelectedChannel(lastChn.ID)
+		c.ScrollToChannel(lastChn.ID)
 	}
 }
 
-// ScrollUp enables us to scroll through the channel list when it overflows
-func (c *Channels) ScrollUp() {
-	// Is cursor at the top of the channel view?
-	if c.CursorPosition == c.List.InnerBounds().Min.Y {
-		if c.Offset > 0 {
-			c.Offset--
-		}
-	} else {
-		c.CursorPosition--
-	}
-}
+// ScrollToChannel repositions the Offset such that when the screen renders, the
+// channel identified by channelID is visible.
+func (c *Channels) ScrollToChannel(channelID string) {
 
-// ScrollDown enables us to scroll through the channel list when it overflows
-func (c *Channels) ScrollDown() {
-	// Is the cursor at the bottom of the channel view?
-	if c.CursorPosition == c.List.InnerBounds().Max.Y-1 {
-		if c.Offset < len(c.ChannelItems)-1 {
-			c.Offset++
+	if _, index, ok := c.findVisibleChannel(channelID); ok {
+		offset := index - (c.maxY() - c.minY()) + 1
+
+		if offset < 0 {
+			c.Offset = 0
+			c.CursorPosition = c.minY() + index
+		} else {
+			c.Offset = offset
+			c.CursorPosition = c.maxY() - 1
 		}
-	} else {
-		c.CursorPosition++
 	}
 }
 
 // Search will search through the channels to find a channel,
 // when a match has been found the selected channel will then
 // be the channel that has been found
-func (c *Channels) Search(term string) {
-	c.SearchMatches = make([]int, 0)
+func (c *Channels) Search(term string) (resultCount int) {
+
+	for _, chn := range c.ChannelItems {
+		if chn.IsSearchResult {
+			chn.IsSearchResult = false
+		}
+	}
 
 	targets := make([]string, 0)
 	for _, c := range c.ChannelItems {
@@ -316,80 +417,122 @@ func (c *Channels) Search(term string) {
 	matches := fuzzy.Find(term, targets)
 
 	for _, m := range matches {
-		for i, item := range c.ChannelItems {
-			if m == item.Name {
-				c.SearchMatches = append(c.SearchMatches, i)
+		for key, chn := range c.ChannelItems {
+			if m == chn.Name {
+				resultCount = resultCount + 1
+				chn.IsSearchResult = true
+				c.ChannelItems[key] = chn
 				break
 			}
 		}
 	}
 
-	if len(c.SearchMatches) > 0 {
-		c.GotoPositionSearch(0)
+	if resultCount > 0 {
+		c.GotoPosition(0)
 		c.SearchPosition = 0
 	}
+
+	return
 }
 
-// GotoPosition is used by to automatically scroll to a specific
-// location in the channels component
-func (c *Channels) GotoPosition(newPos int) {
+// GotoPosition scrolls the channel list to a new position in the current search results
+func (c *Channels) GotoPosition(newPos int) (ok bool) {
 
-	// Is the new position in range of the current view?
-	minRange := c.Offset
-	maxRange := c.Offset + (c.List.InnerBounds().Max.Y - 2)
-
-	if newPos < minRange {
-		// newPos is above, we need to scroll up.
-		c.SetSelectedChannel(newPos)
-
-		// How much do we need to scroll to get it into range?
-		c.Offset = c.Offset - (minRange - newPos)
-	} else if newPos > maxRange {
-		// newPos is below, we need to scroll down
-		c.SetSelectedChannel(newPos)
-
-		// How much do we need to scroll to get it into range?
-		c.Offset = c.Offset + (newPos - maxRange)
-	} else {
-		// newPos is inside range
-		c.SetSelectedChannel(newPos)
+	// there's nothing to be done if there are no search results, or the given
+	// position is out of range
+	var results []string
+	if results = c.listSearchResults(); len(results) == 0 ||
+		newPos > len(results)-1 ||
+		newPos < 0 {
+		return
 	}
 
-	// Set cursor to correct position
-	c.CursorPosition = (newPos - c.Offset) + 1
+	newChannelID := results[newPos]
+	if _, ok = c.ChannelItems[newChannelID]; !ok {
+		return
+	}
+
+	c.SetSelectedChannel(newChannelID)
+	c.ScrollToChannel(newChannelID)
+
+	return true
 }
 
-// GotoPosition is used by the search functionality to automatically
-// scroll to a specific location in the channels component
-func (c *Channels) GotoPositionSearch(position int) {
-	newPos := c.SearchMatches[position]
-	c.GotoPosition(newPos)
-}
-
-// SearchNext allows us to cycle through the c.SearchMatches
+// SearchNext allows us to cycle through search results
 func (c *Channels) SearchNext() {
 	newPosition := c.SearchPosition + 1
-	if newPosition <= len(c.SearchMatches)-1 {
-		c.GotoPositionSearch(newPosition)
+	if ok := c.GotoPosition(newPosition); ok {
 		c.SearchPosition = newPosition
 	}
 }
 
-// SearchPrev allows us to cycle through the c.SearchMatches
+// SearchPrev allows us to cycle through search results
 func (c *Channels) SearchPrev() {
 	newPosition := c.SearchPosition - 1
-	if newPosition >= 0 {
-		c.GotoPositionSearch(newPosition)
+	if ok := c.GotoPosition(newPosition); ok {
 		c.SearchPosition = newPosition
 	}
 }
 
 // Jump to the first channel with a notification
 func (c *Channels) Jump() {
-	for i, channel := range c.ChannelItems {
-		if channel.Notification {
-			c.GotoPosition(i)
+
+	for _, chnID := range c.channelIDs {
+
+		if c.ChannelItems[chnID].Notification {
+			c.SetSelectedChannel(chnID)
+			c.ScrollToChannel(chnID)
 			break
 		}
 	}
+}
+
+// findVisibleChannels finds a channel by ID in the visible channel list
+func (c *Channels) findVisibleChannel(channelID string) (chn *ChannelItem, idx int, ok bool) {
+
+	for i, channel := range c.ListChannels() {
+		if channel.ID == channelID {
+			chn = channel
+			idx = i
+			ok = true
+			break
+		}
+	}
+
+	return
+}
+
+// listSearchResults lists the IDs of the channel that are search results
+func (c *Channels) listSearchResults() (channelIDs []string) {
+	for _, chn := range c.ListChannels() {
+		if chn.IsSearchResult {
+			channelIDs = append(channelIDs, chn.ID)
+		}
+	}
+
+	return
+}
+
+// maxCursorPos returns the y coordinate beyond which the cursor may not advance
+func (c *Channels) maxCursorPos() int {
+	return c.minY() + c.itemsRendered - 1
+}
+
+// maxY returns the largest Y value that may be rendered in this component
+func (c *Channels) maxY() int {
+	return c.List.InnerBounds().Max.Y
+}
+
+// minY returns the largets Y value that may be rendered in this component
+func (c *Channels) minY() int {
+	return c.List.InnerBounds().Min.Y
+}
+
+func (c *Channels) shouldBeVisible(chn *ChannelItem) bool {
+
+	if !c.UnreadOnly {
+		return true
+	}
+
+	return chn.ID == c.SelectedChannel || chn.Notification || chn.IsSearchResult
 }

--- a/components/threads.go
+++ b/components/threads.go
@@ -18,9 +18,10 @@ func CreateThreadsComponent(height int) *Threads {
 	threads.List.BorderLabel = "Threads"
 	threads.List.Height = height
 
-	threads.SelectedChannel = 0
+	threads.SelectedChannel = ""
 	threads.Offset = 0
 	threads.CursorPosition = threads.List.InnerBounds().Min.Y
+	threads.ChannelItems = make(map[string]*ChannelItem)
 
 	return threads
 }

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	ThreadsWidth int                   `json:"threads_width"`
 	KeyMap       map[string]keyMapping `json:"key_map"`
 	Theme        Theme                 `json:"theme"`
+	UnreadOnly   bool                  `json:"show_unread_only"`
 }
 
 type keyMapping map[string]string
@@ -94,6 +95,7 @@ func getDefaultConfig() Config {
 		ThreadsWidth: 1,
 		Notify:       "",
 		Emoji:        false,
+		UnreadOnly:   false,
 		KeyMap: map[string]keyMapping{
 			"command": {
 				"i":          "mode-insert",

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
 )
+
+replace github.com/nlopes/slack => ../slack

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/0xAX/notificator v0.0.0-20171022182052-88d57ee9043b h1:Sn+u6zpXFyfm2X7ruh+z6SJiUVyFg8YElh6HIOhrRCA=
 github.com/0xAX/notificator v0.0.0-20171022182052-88d57ee9043b/go.mod h1:NtXa9WwQsukMHZpjNakTTz0LArxvGYdPA9CjIcUSZ6s=
+github.com/acaloiaro/slack v0.6.1 h1:q1UT6Sv57ojq1AO1k5EF4gJpowA42qKj7pKW77P9eIY=
+github.com/acaloiaro/slack v0.6.1/go.mod h1:45gdOh7+WJN/aHOVomIpwm/BZc8RXduFm2liA06f73I=
+github.com/acaloiaro/slack v0.6.2 h1:h/exJfi52Mj98cLCYIYvGp0SExJvGtpyU8wH/lhsx0o=
+github.com/acaloiaro/slack v0.6.2/go.mod h1:3oqZLevjlFjJuMPy2yVe/hMFdgCk55MnTi1gxVPjwm8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/views/view.go
+++ b/views/view.go
@@ -24,7 +24,7 @@ func CreateView(config *config.Config, svc *service.SlackService) (*View, error)
 
 	// Channels: create the component
 	sideBarHeight := termui.TermHeight() - input.Par.Height
-	channels := components.CreateChannelsComponent(sideBarHeight)
+	channels := components.CreateChannelsComponent(sideBarHeight, config.UnreadOnly)
 
 	// Channels: fill the component
 	slackChans, err := svc.GetChannels()
@@ -42,31 +42,30 @@ func CreateView(config *config.Config, svc *service.SlackService) (*View, error)
 	chat := components.CreateChatComponent(input.Par.Height)
 
 	// Chat: fill the component
-	msgs, thr, err := svc.GetMessages(
-		channels.ChannelItems[channels.SelectedChannel].ID,
-		chat.GetMaxItems(),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Chat: set messages in component
-	chat.SetMessages(msgs)
-
-	chat.SetBorderLabel(
-		channels.ChannelItems[channels.SelectedChannel].GetChannelName(),
-	)
-
-	// Threads: set threads in component
-	if len(thr) > 0 {
-
-		// Make the first thread the current Channel
-		threads.SetChannels(
-			append(
-				[]components.ChannelItem{channels.GetSelectedChannel()},
-				thr...,
-			),
+	if chn, ok := channels.GetSelectedChannel(); ok {
+		msgs, thr, err := svc.GetMessages(
+			chn.ID,
+			chat.GetMaxItems(),
 		)
+		if err != nil {
+			return nil, err
+		}
+
+		// Chat: set messages in component
+		chat.SetMessages(msgs)
+		chat.SetBorderLabel(chn.GetChannelName())
+
+		// Threads: set threads in component
+		if len(thr) > 0 {
+
+			// Make the first thread the current Channel
+			threads.SetChannels(
+				append(
+					[]*components.ChannelItem{chn},
+					thr...,
+				),
+			)
+		}
 	}
 
 	// Debug: create the component


### PR DESCRIPTION
This PR adds support for a new config option `"show_unread_only": true` that results in only unread messsages being shown in the channel list. 

Fixes https://github.com/erroneousboat/slack-term/issues/214