### PR TITLE
Upgrade xdg to 1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/0xAX/notificator v0.0.0-20171022182052-88d57ee9043b
-	github.com/OpenPeeDeeP/xdg v0.2.0
+	github.com/OpenPeeDeeP/xdg v1.0.0
 	github.com/erroneousboat/termui v0.0.0-20170923115141-80f245cdfa04
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/0xAX/notificator v0.0.0-20171022182052-88d57ee9043b h1:Sn+u6zpXFyfm2X
 github.com/0xAX/notificator v0.0.0-20171022182052-88d57ee9043b/go.mod h1:NtXa9WwQsukMHZpjNakTTz0LArxvGYdPA9CjIcUSZ6s=
 github.com/OpenPeeDeeP/xdg v0.2.0 h1:xr89rnllbkRkM7SV9Y++FJ8TGkbdkhhBQm5kOkGT7AE=
 github.com/OpenPeeDeeP/xdg v0.2.0/go.mod h1:tMoSueLQlMf0TCldjrJLNIjAc5qAOIcHt5REi88/Ygo=
+github.com/OpenPeeDeeP/xdg v1.0.0 h1:UDLmNjCGFZZCaVMB74DqYEtXkHxnTxcr4FeJVF9uCn8=
+github.com/OpenPeeDeeP/xdg v1.0.0/go.mod h1:tMoSueLQlMf0TCldjrJLNIjAc5qAOIcHt5REi88/Ygo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vendor/github.com/OpenPeeDeeP/xdg/README.md
+++ b/vendor/github.com/OpenPeeDeeP/xdg/README.md
@@ -1,6 +1,6 @@
 # XDG [![Build status](https://ci.appveyor.com/api/projects/status/9eoupq9jgsu2p0jv?svg=true)](https://ci.appveyor.com/project/dixonwille/xdg) [![Build Status](https://travis-ci.org/OpenPeeDeeP/xdg.svg?branch=master)](https://travis-ci.org/OpenPeeDeeP/xdg) [![Go Report Card](https://goreportcard.com/badge/github.com/OpenPeeDeeP/xdg)](https://goreportcard.com/report/github.com/OpenPeeDeeP/xdg) [![GoDoc](https://godoc.org/github.com/OpenPeeDeeP/xdg?status.svg)](https://godoc.org/github.com/OpenPeeDeeP/xdg) [![codecov](https://codecov.io/gh/OpenPeeDeeP/xdg/branch/master/graph/badge.svg)](https://codecov.io/gh/OpenPeeDeeP/xdg)
 
-A cross platform package that tries to follow [XDG Standard](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) when possible. Since XDG is linux specific, I am only able to follow standards to the T on linux. But for the other operating systems I am finding similar best practice locations for the files.
+A cross platform package that tries to follow [XDG Standard](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) when possible. Since XDG is linux specific, I am only able to follow standards to the T on linux. But for the other operating systems I am finding similar best practice locations for the files.
 
 ## Locations Per OS
 
@@ -8,13 +8,13 @@ The following table shows what is used if the envrionment variable is not set. I
 
 > When creating `XDG` application the `Vendor` and `Application` names are appeneded to the end of the path to keep projects unique.
 
-|  | Linux | Mac | Windows |
+|  | Linux(and BSD) | Mac | Windows |
 | ---: | :---: | :---: | :---: |
 | `XDG_DATA_DIRS` | [`/usr/local/share`, `/usr/share`] | [`/Library/Application Support`] | `%PROGRAMDATA%` |
 | `XDG_DATA_HOME` | `~/.local/share` | `~/Library/Application Support` | `%APPDATA%` |
 | `XDG_CONFIG_DIRS` | [`/etc/xdg`] | [`/Library/Application Support`] | `%PROGRAMDATA%` |
 | `XDG_CONFIG_HOME` | `~/.config` | `~/Library/Application Support` | `%APPDATA%` |
-| `XDG_CACHE_HOME` | `~/.cache` | `~/Library/Cache` | `%LOCALAPPDATA%` |
+| `XDG_CACHE_HOME` | `~/.cache` | `~/Library/Caches` | `%LOCALAPPDATA%` |
 
 ## Notes
 

--- a/vendor/github.com/OpenPeeDeeP/xdg/xdg_bsd.go
+++ b/vendor/github.com/OpenPeeDeeP/xdg/xdg_bsd.go
@@ -1,0 +1,32 @@
+// +build freebsd openbsd netbsd
+
+// Copyright (c) 2017, OpenPeeDeeP. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xdg
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func (o *osDefaulter) defaultDataHome() string {
+	return filepath.Join(os.Getenv("HOME"), ".local", "share")
+}
+
+func (o *osDefaulter) defaultDataDirs() []string {
+	return []string{"/usr/local/share/", "/usr/share/"}
+}
+
+func (o *osDefaulter) defaultConfigHome() string {
+	return filepath.Join(os.Getenv("HOME"), ".config")
+}
+
+func (o *osDefaulter) defaultConfigDirs() []string {
+	return []string{"/etc/xdg"}
+}
+
+func (o *osDefaulter) defaultCacheHome() string {
+	return filepath.Join(os.Getenv("HOME"), ".cache")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/0xAX/notificator v0.0.0-20171022182052-88d57ee9043b
 github.com/0xAX/notificator
-# github.com/OpenPeeDeeP/xdg v0.2.0
+# github.com/OpenPeeDeeP/xdg v1.0.0
 github.com/OpenPeeDeeP/xdg
 # github.com/erroneousboat/termui v0.0.0-20170923115141-80f245cdfa04
 github.com/erroneousboat/termui


### PR DESCRIPTION
xdg has added support for BSDs, needed to build slack-term on OpenBSD.  Tested + working.

Please read [CONTRIBUTING.md](https://github.com/erroneousboat/slack-term/blob/master/CONTRIBUTING.md)
